### PR TITLE
Improve mimic_utils module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ target/
 
 # PyCharm / JetBrains
 .idea
+# Debian package
+*.deb

--- a/src/mimic_utils/__init__.py
+++ b/src/mimic_utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for the MIMIC dataset."""
+
+__all__ = ["__version__"]
+
+__version__ = "1.0.0"

--- a/src/mimic_utils/sqlglot_dialects/bigquery.py
+++ b/src/mimic_utils/sqlglot_dialects/bigquery.py
@@ -1,6 +1,6 @@
 import sqlglot
 import sqlglot.dialects.bigquery
-from sqlglot import Expression, exp, select
+from sqlglot import exp
 from sqlglot.helper import seq_get
 
 sqlglot.dialects.bigquery.BigQuery.Parser.FUNCTIONS["PARSE_DATETIME"] = lambda args: exp.StrToTime(

--- a/src/mimic_utils/sqlglot_dialects/duckdb.py
+++ b/src/mimic_utils/sqlglot_dialects/duckdb.py
@@ -1,8 +1,7 @@
 import sqlglot
 import sqlglot.dialects.duckdb
 from sqlglot.dialects.duckdb import DuckDB
-from sqlglot import Expression, exp, select
-from sqlglot.helper import seq_get
+from sqlglot import Expression, exp
 
 # Monkey patches for duckdb
 # (1) date_sub / date_add

--- a/src/mimic_utils/transpile.py
+++ b/src/mimic_utils/transpile.py
@@ -11,9 +11,9 @@ from sqlglot.expressions import to_identifier
 
 # Apply transformation monkey patches
 # these modules are imported for their side effects
-from mimic_utils.sqlglot_dialects import postgres
-from mimic_utils.sqlglot_dialects import bigquery
-from mimic_utils.sqlglot_dialects import duckdb
+from mimic_utils.sqlglot_dialects import postgres  # noqa: F401
+from mimic_utils.sqlglot_dialects import bigquery  # noqa: F401
+from mimic_utils.sqlglot_dialects import duckdb  # noqa: F401
 
 # sqlglot has a default convention that function names are upper-case
 _FUNCTION_MAPPING = {


### PR DESCRIPTION
## Summary
- add `__version__` in `mimic_utils` package
- silence unused import warnings in dialect modules
- ignore Debian package artifacts

## Testing
- `python -m py_compile $(cat pyfiles.txt)` *(fails: file not found)*
- `pytest -q` *(fails: KeyboardInterrupt)*
